### PR TITLE
Add privacy policy page with footer link

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>View IPTV</title>
+    <title>View IPTV | VIew-IPTV.stream</title>
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- hls.js -->
@@ -72,6 +72,7 @@
         <p class="font-semibold">View-IPTV.stream</p>
         <p>Copyright &copy; 2025 Sideways Thought LLC.</p>
         <p><a href="#" class="text-blue-600 hover:underline">Contact Us</a></p>
+        <p><a href="privacy.html" class="text-blue-600 hover:underline">Privacy Policy</a></p>
     </footer>
 
     <script src="main.js"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Policy | VIew-IPTV.stream</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-gray-100 text-gray-900">
+    <nav class="sr-only focus-within:not-sr-only absolute left-2 top-2 bg-white p-2 rounded shadow space-y-2">
+        <a href="#policy" class="block">Skip to content</a>
+    </nav>
+    <main id="policy" tabindex="-1" class="container mx-auto p-6 max-w-5xl space-y-6">
+        <header class="space-y-2">
+            <h1 class="text-3xl font-bold">Privacy Policy</h1>
+            <p>Effective as of May 16, 2025</p>
+        </header>
+        <section class="space-y-4">
+            <p>
+                This Privacy Policy ("Policy") applies to VIew-IPTV.stream and SIdeways
+                Thought LLC ("Company") and governs data collection and usage. Unless
+                otherwise noted, all references to the Company include View-IPTV.site. The
+                Company's application is a stream playlist viewer and information site. By
+                using the application, you consent to the data practices described in this
+                statement.
+            </p>
+            <h2 class="text-2xl font-semibold">Collection of Your Personal Information</h2>
+            <p>The Company may collect anonymous demographic information such as your:</p>
+            <ul class="list-disc list-inside">
+                <li>Age</li>
+                <li>Gender</li>
+            </ul>
+            <p>
+                We do not collect personal information unless you voluntarily provide it. You
+                may be required to provide certain information when using specific services,
+                for example when registering for an account, entering a contest, signing up
+                for special offers, sending an email, or submitting payment information. We
+                will use your information to communicate with you regarding services or
+                products you request. Additional personal or non-personal information may be
+                gathered in the future.
+            </p>
+            <h2 class="text-2xl font-semibold">Sharing Information with Third Parties</h2>
+            <p>The Company does not sell, rent, or lease its customer lists to third parties.</p>
+            <p>
+                We may share data with trusted partners to help perform statistical analysis,
+                send you email or postal mail, provide customer support, or arrange for
+                deliveries. These third parties are prohibited from using your personal
+                information except to provide these services to the Company, and they must
+                maintain its confidentiality.
+            </p>
+            <p>
+                The Company may disclose your personal information, without notice, if
+                required to do so by law or in the good faith belief that such action is
+                necessary to comply with legal process, protect and defend the rights or
+                property of the Company, or act under exigent circumstances to protect the
+                personal safety of users or the public.
+            </p>
+            <h2 class="text-2xl font-semibold">Right to Deletion</h2>
+            <p>Upon a verifiable request from you, we will:</p>
+            <ul class="list-disc list-inside">
+                <li>Delete your personal information from our records; and</li>
+                <li>Direct service providers to delete your personal information from their records.</li>
+            </ul>
+            <p>We may be unable to comply with a deletion request if it is necessary to:</p>
+            <ul class="list-disc list-inside space-y-1">
+                <li>Complete a transaction or perform a contract with you;</li>
+                <li>Detect security incidents or protect against malicious activity;</li>
+                <li>Debug to identify and repair errors;</li>
+                <li>Exercise or ensure the right of free speech;</li>
+                <li>Comply with the California Electronic Communications Privacy Act;</li>
+                <li>
+                    Conduct public or peer-reviewed research in the public interest when
+                    deletion would render the research impossible or seriously impair it;
+                </li>
+                <li>Enable solely internal uses aligned with your expectations;</li>
+                <li>Comply with a legal obligation; or</li>
+                <li>Otherwise use the information internally in a lawful manner compatible with the context in which you provided it.</li>
+            </ul>
+            <h2 class="text-2xl font-semibold">Children Under Thirteen</h2>
+            <p>
+                The Company does not knowingly collect personally identifiable information
+                from children under the age of 13. If you are under 13, you must ask your
+                parent or guardian for permission to use this application.
+            </p>
+            <h2 class="text-2xl font-semibold">Changes to This Statement</h2>
+            <p>
+                The Company reserves the right to change this Policy from time to time—for
+                example, when services or legal requirements change. When changes are
+                significant, we will inform you, such as by emailing the address on your
+                account or placing a prominent notice on our site. Your continued use of the
+                application after such modifications constitutes acknowledgment and
+                agreement to the modified Policy.
+            </p>
+            <h2 class="text-2xl font-semibold">Contact Information</h2>
+            <p>
+                The Company welcomes your questions or comments regarding this Policy. If
+                you believe that the Company has not adhered to it, please contact us at:
+            </p>
+            <address class="not-italic space-y-1">
+                <div>SIdeways Thought LLC</div>
+                <div>777 N Jefferson St</div>
+                <div>Suite 408 PMB 1023</div>
+                <div>Milwaukee, Wisconsin 53202</div>
+                <div>Email: <a class="text-blue-600 hover:underline" href="mailto:info@view-iptv.stream">info@view-iptv.stream</a></div>
+                <div>Phone: <a class="text-blue-600 hover:underline" href="tel:262-288-4998">262-288-4998</a></div>
+            </address>
+        </section>
+    </main>
+    <footer class="bg-gray-200 text-center py-4 mt-8">
+        <p class="font-semibold">View-IPTV.stream</p>
+        <p>Copyright &copy; 2025 Sideways Thought LLC.</p>
+        <p><a href="index.html" class="text-blue-600 hover:underline">Return to home</a></p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `privacy.html` using accessible markup for the privacy policy
- link to the privacy page from the footer of `index.html`
- update page titles to use the `| VIew-IPTV.stream` format

## Testing
- `git log -1 --stat`
