### PR TITLE
Implement proxy safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ A lightweight IPTV/HLS stream explorer and player.
 
 ### Features
 - Pass `playlist` and optional `program` parameters in the URL to automatically load a playlist and play a stream.
+- The PHP proxy limits each response to 5 MB, rate limits clients by IP and
+  periodically cleans its cache.

--- a/proxy.php
+++ b/proxy.php
@@ -1,6 +1,65 @@
 <?php
 session_start();
 
+// Configuration
+define('CACHE_TTL', 300); // 5 minutes
+define('MAX_DOWNLOAD_BYTES', 5 * 1024 * 1024); // 5 MB
+define('RATE_LIMIT', 30); // requests
+define('RATE_WINDOW', 3600); // per hour
+define('RATE_DIR', sys_get_temp_dir() . '/proxy_rate');
+
+function cleanup_cache() {
+    if (!isset($_SESSION['proxy_cache'])) {
+        return;
+    }
+    $now = time();
+    foreach ($_SESSION['proxy_cache'] as $k => $entry) {
+        if ($entry['time'] + CACHE_TTL <= $now) {
+            unset($_SESSION['proxy_cache'][$k]);
+        }
+    }
+}
+
+function rate_limit() {
+    $dir = RATE_DIR;
+    if (!is_dir($dir)) {
+        mkdir($dir, 0700, true);
+    }
+    $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+    $file = $dir . '/' . sha1($ip);
+    $now = time();
+    $entries = [];
+    if (file_exists($file)) {
+        $json = file_get_contents($file);
+        $entries = json_decode($json, true) ?: [];
+    }
+    $entries = array_values(array_filter($entries, fn($t) => $t + RATE_WINDOW > $now));
+    if (count($entries) >= RATE_LIMIT) {
+        http_response_code(429);
+        echo 'Too many requests';
+        exit;
+    }
+    $entries[] = $now;
+    file_put_contents($file, json_encode($entries));
+
+    // Cleanup old files
+    foreach (glob($dir . '/*') as $f) {
+        $data = json_decode(@file_get_contents($f), true);
+        if (!is_array($data)) {
+            @unlink($f);
+            continue;
+        }
+        $data = array_values(array_filter($data, fn($t) => $t + RATE_WINDOW > $now));
+        if (empty($data)) {
+            @unlink($f);
+        } else {
+            file_put_contents($f, json_encode($data));
+        }
+    }
+}
+
+cleanup_cache();
+
 $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
 $referer = $_SERVER['HTTP_REFERER'] ?? '';
 $host = $_SERVER['HTTP_HOST'];
@@ -23,6 +82,8 @@ if (!$allowed) {
     echo "Forbidden";
     exit;
 }
+
+rate_limit();
 
 $url = $_GET['url'] ?? '';
 if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
@@ -50,25 +111,41 @@ if (!isset($_SESSION['proxy_cache'])) {
     $_SESSION['proxy_cache'] = [];
 }
 
-if (isset($_SESSION['proxy_cache'][$key]) && $_SESSION['proxy_cache'][$key]['time'] + 300 > time()) {
+if (isset($_SESSION['proxy_cache'][$key]) && $_SESSION['proxy_cache'][$key]['time'] + CACHE_TTL > time()) {
     $entry = $_SESSION['proxy_cache'][$key];
     $data = $entry['data'];
     $type = $entry['type'];
 } else {
     $ch = curl_init($url);
     curl_setopt_array($ch, [
-        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_RETURNTRANSFER => false,
         CURLOPT_USERAGENT => 'IPTV-Proxy',
         CURLOPT_FOLLOWLOCATION => true,
         CURLOPT_CONNECTTIMEOUT => 10,
         CURLOPT_TIMEOUT => 20,
     ]);
-    $data = curl_exec($ch);
-    if ($data === false) {
-        http_response_code(502);
-        echo "Failed to fetch";
+    $buffer = '';
+    curl_setopt($ch, CURLOPT_WRITEFUNCTION, function($ch, $chunk) use (&$buffer) {
+        $buffer .= $chunk;
+        if (strlen($buffer) > MAX_DOWNLOAD_BYTES) {
+            return 0; // abort
+        }
+        return strlen($chunk);
+    });
+    curl_exec($ch);
+    if (curl_errno($ch) === CURLE_WRITE_ERROR && strlen($buffer) > MAX_DOWNLOAD_BYTES) {
+        http_response_code(413);
+        echo 'Response too large';
+        curl_close($ch);
         exit;
     }
+    if (curl_errno($ch)) {
+        http_response_code(502);
+        echo 'Failed to fetch';
+        curl_close($ch);
+        exit;
+    }
+    $data = $buffer;
     $type = curl_getinfo($ch, CURLINFO_CONTENT_TYPE) ?: 'text/plain';
     curl_close($ch);
     $_SESSION['proxy_cache'][$key] = [


### PR DESCRIPTION
## Summary
- limit proxy downloads to 5 MB with cURL write callback
- add per-IP rate limiting using a temp file store
- periodically clean up cached proxy entries
- document new proxy limitations in README

## Testing
- `php -l proxy.php` *(fails: command not found)*