### PR TITLE
Enforce HTTPS-only playlist proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ A lightweight IPTV/HLS stream explorer and player.
 
 ### Features
 - Pass `playlist` and optional `program` parameters in the URL to automatically load a playlist and play a stream.
-- The PHP proxy limits each response to 5 MB, rate limits clients by IP and
+- The PHP proxy limits each response to 3.5 MB, rate limits clients by IP and
   periodically cleans its cache.


### PR DESCRIPTION
## Summary
- restrict proxy to GET and HTTPS port
- only allow fetching HTTPS URLs ending with `.m3u` or `.m3u8`
- disable follow redirects and reject 3xx responses
- lower playlist size limit to 3.5 MB
- document new limit in README

## Testing
- `php -v` *(fails: command not found)*