### PR TITLE
Add settings modal with dark mode

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@ $pageTitle = 'View IPTV';
 <!DOCTYPE html>
 <html lang="en">
 <?php include 'partials/head.php'; ?>
-<body class="min-h-screen bg-gray-100 text-gray-900">
+<body class="min-h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
     <nav class="sr-only focus-within:not-sr-only absolute left-2 top-2 bg-white p-2 rounded shadow space-y-2">
         <a href="#playlistForm" class="block">Skip to playlist</a>
         <a href="#videoPlayer" class="block">Skip to video player</a>

--- a/main.js
+++ b/main.js
@@ -352,3 +352,67 @@ function doShare(url) {
     prompt("Copy this link:", url);
   }
 }
+
+// ------- Theme settings -------
+const settingsBtn = document.getElementById("settingsBtn");
+const settingsModal = document.getElementById("settingsModal");
+const closeSettingsBtn = document.getElementById("closeSettingsBtn");
+const themeSelect = document.getElementById("themeSelect");
+
+function applyTheme(value) {
+  if (value === "dark") {
+    document.documentElement.classList.add("dark");
+  } else if (value === "light") {
+    document.documentElement.classList.remove("dark");
+  } else {
+    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }
+}
+
+function loadTheme() {
+  const saved = localStorage.getItem("theme") || "system";
+  if (themeSelect) themeSelect.value = saved;
+  applyTheme(saved);
+}
+
+function saveTheme(value) {
+  localStorage.setItem("theme", value);
+  applyTheme(value);
+}
+
+if (settingsBtn && settingsModal && closeSettingsBtn && themeSelect) {
+  settingsBtn.addEventListener("click", () => {
+    settingsModal.classList.remove("hidden");
+    themeSelect.focus();
+  });
+
+  closeSettingsBtn.addEventListener("click", () => {
+    settingsModal.classList.add("hidden");
+    settingsBtn.focus();
+  });
+
+  settingsModal.addEventListener("click", (e) => {
+    if (e.target === settingsModal) {
+      settingsModal.classList.add("hidden");
+      settingsBtn.focus();
+    }
+  });
+
+  themeSelect.addEventListener("change", () => {
+    saveTheme(themeSelect.value);
+  });
+
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", () => {
+      if ((localStorage.getItem("theme") || "system") === "system") {
+        applyTheme("system");
+      }
+    });
+
+  document.addEventListener("DOMContentLoaded", loadTheme);
+}

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -1,4 +1,4 @@
-<footer class="bg-gray-200 text-center py-4 mt-8">
+<footer class="bg-gray-200 dark:bg-gray-800 text-center py-4 mt-8">
     <p class="font-semibold">View-IPTV.stream</p>
     <p>Copyright &copy; 2025 Sideways Thought LLC.</p>
     <p><a href="index.php" class="text-blue-600 hover:underline">Home</a> | <a href="privacy.php" class="text-blue-600 hover:underline">Privacy Policy</a></p>

--- a/partials/head.php
+++ b/partials/head.php
@@ -11,7 +11,19 @@ if (empty($pageTitle)) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title><?php echo htmlspecialchars($pageTitle); ?></title>
     <!-- Tailwind CSS -->
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme');
+            if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                document.documentElement.classList.add('dark');
+            }
+        })();
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-RXf+QSDCUQs5u3F4dmkB9pGwBuiJTqXrE2RzYhWnEfZ1CMBYHZB+m0XXq20s96VdY+U2/6YdEcXkoP4zTPU3HQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <!-- hls.js -->
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <?php include 'partials/analytics.php'; ?>

--- a/partials/header.php
+++ b/partials/header.php
@@ -1,8 +1,28 @@
-<header class="bg-gray-200">
+<header class="bg-gray-200 dark:bg-gray-800">
     <div class="container mx-auto max-w-6xl flex justify-between items-center p-4">
         <div class="font-semibold">View-IPTV.stream</div>
         <nav class="space-x-4 flex items-center">
             <a href="index.php" class="text-blue-600 hover:underline">Home</a>
+            <button id="settingsBtn" class="text-blue-600 p-1" aria-haspopup="dialog">
+                <i class="fa-solid fa-gear w-5 h-5" aria-hidden="true"></i>
+                <span class="sr-only">Settings</span>
+            </button>
         </nav>
     </div>
 </header>
+<div id="settingsModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+    <div class="bg-white dark:bg-gray-800 p-4 rounded shadow w-80" role="dialog" aria-modal="true" aria-labelledby="settingsTitle">
+        <h2 id="settingsTitle" class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-2">Settings</h2>
+        <label class="block">
+            <span class="text-gray-700 dark:text-gray-300">Theme</span>
+            <select id="themeSelect" class="mt-1 block w-full border rounded px-2 py-1 bg-white dark:bg-gray-700 dark:text-gray-100">
+                <option value="system">System</option>
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+            </select>
+        </label>
+        <div class="flex justify-end mt-4">
+            <button id="closeSettingsBtn" class="px-4 py-2 bg-blue-600 text-white rounded">Close</button>
+        </div>
+    </div>
+</div>

--- a/privacy.php
+++ b/privacy.php
@@ -5,7 +5,7 @@ $pageTitle = 'Privacy Policy';
 <!DOCTYPE html>
 <html lang="en">
 <?php include 'partials/head.php'; ?>
-<body class="min-h-screen bg-gray-100 text-gray-900">
+<body class="min-h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
     <nav class="sr-only focus-within:not-sr-only absolute left-2 top-2 bg-white p-2 rounded shadow space-y-2">
         <a href="#policy" class="block">Skip to content</a>
     </nav>


### PR DESCRIPTION
## Summary
- add dark mode initialization in page head
- provide gear icon and settings modal for theme selection
- allow user override of theme with localStorage
- style pages and layout to support dark mode
- use Font Awesome gear icon instead of inline SVG

## Testing
- `git status --short`
