### PR TITLE
Add IPv6 validation for proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ A lightweight IPTV/HLS stream explorer and player.
 - Pass `playlist` and optional `program` parameters in the URL to automatically load a playlist and play a stream.
 - The PHP proxy limits each response to 3.5 MB, rate limits clients by IP and
   periodically cleans its cache.
+- The proxy validates IPv4 and IPv6 addresses to support modern DNS records.


### PR DESCRIPTION
## Summary
- support IPv6 DNS records in `proxy.php`
- ensure proxied connections use public IP addresses
- document IPv6 support in README

## Testing
- `php -l proxy.php` *(fails: `php` not installed)*